### PR TITLE
Use Travis CI for automated testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,98 @@
+# This file is used to configure the Travis CI tests of this library
+
+env:
+  global:
+    # The Arduino IDE will be installed at APPLICATION_FOLDER/arduino
+    - APPLICATION_FOLDER="${HOME}/arduino-ci-script-application-folder"
+    - SKETCHBOOK_FOLDER="${HOME}/arduino-sketchbook"
+
+
+matrix:
+  include:
+  - name: "Compilation tests"
+    language: minimal
+    install:
+      # Install the Arduino IDE
+      - install_ide 'newest'
+      # Install Arduino SAMD Boards
+      - install_package 'arduino:samd'
+      # Install the 107-Arduino-MCP2515 library
+      - install_library
+    script:
+      # Compile all example sketches
+      - build_sketch "${SKETCHBOOK_FOLDER}/libraries/107-Arduino-MCP2515/examples" 'arduino:samd:mkrvidor4000' 'false' 'newest'
+    after_script:
+      # Print a tab separated report of all sketch verification results to the log
+      - display_report
+
+
+  - name: 'Extra library checks'
+    language: minimal
+    script:
+      - check_library_structure "${TRAVIS_BUILD_DIR}"
+      - check_library_properties "${TRAVIS_BUILD_DIR}"
+      - check_keywords_txt "${TRAVIS_BUILD_DIR}"
+      - check_library_manager_compliance "${TRAVIS_BUILD_DIR}"
+
+
+  - name: 'Spell check'
+    language: python
+    python: 3.6
+    # Define an empty before_install phase to override the default definition
+    before_install:
+    install:
+      # https://github.com/codespell-project/codespell
+      - pip install codespell
+    script:
+      - codespell --skip="${TRAVIS_BUILD_DIR}/.git" --ignore-words="${TRAVIS_BUILD_DIR}/etc/codespell-ignore-words-list.txt" "${TRAVIS_BUILD_DIR}"
+
+
+  - name: 'File formatting checks'
+    language: minimal
+    # Define empty phases to override the default definitions
+    before_install:
+    script:
+      # Check for files starting with a blank line
+      - find . -path './.git' -prune -or -type f -print0 | xargs -0 -L1 bash -c 'head -1 "$0" | grep --binary-files=without-match --regexp="^$"; if [[ "$?" == "0" ]]; then echo "Blank line found at start of $0."; false; fi'
+      # Check for tabs
+      - find . -path './.git' -prune -or \( -not -name 'keywords.txt' -and -type f \) -exec grep --with-filename --line-number --binary-files=without-match --regexp=$'\t' '{}' \; -exec echo 'Tab found.' \; -exec false '{}' +
+      # Check for trailing whitespace
+      - find . -path './.git' -prune -or -type f -exec grep --with-filename --line-number --binary-files=without-match --regexp='[[:blank:]]$' '{}' \; -exec echo 'Trailing whitespace found.' \; -exec false '{}' +
+      # Check for non-Unix line endings
+      - find . -path './.git' -prune -or -type f -exec grep --files-with-matches --binary-files=without-match --regexp=$'\r$' '{}' \; -exec echo 'Non-Unix EOL detected.' \; -exec false '{}' +
+      # Check for blank lines at end of files
+      - find . -path './.git' -prune -or -type f -print0 | xargs -0 -L1 bash -c 'tail -1 "$0" | grep --binary-files=without-match --regexp="^$"; if [[ "$?" == "0" ]]; then echo "Blank line found at end of $0."; false; fi'
+      # Check for files that don't end in a newline (https://stackoverflow.com/a/25686825)
+      - find . -path './.git' -prune -or -type f -print0 | xargs -0 -L1 bash -c 'if test "$(grep --files-with-matches --binary-files=without-match --max-count=1 --regexp='.*' "$0")" && test "$(tail --bytes=1 "$0")"; then echo "No new line at end of $0."; false; fi'
+
+
+# default phase definitions
+before_install:
+  # install arduino-ci-script
+  - git clone https://github.com/per1234/arduino-ci-script.git "${HOME}/scripts/arduino-ci-script"
+  - cd "${HOME}/scripts/arduino-ci-script"
+  # Get new tags from the remote
+  - git fetch --tags
+  # Checkout the latest tag
+  - git checkout $(git describe --tags `git rev-list --tags --max-count=1`)
+  - source "${HOME}/scripts/arduino-ci-script/arduino-ci-script.sh"
+
+  # These functions can be used to get verbose output for debugging arduino-ci-script
+  # set_script_verbosity can be set to values from 0 - 2 (verbosity off - maximum verbosity)
+  #- set_script_verbosity 1
+  # Setting set_verbose_output_during_compilation to true is the same as File > Preferences > Show verbose output during > compilation (check) in the Arduino IDE
+  #- set_verbose_output_during_compilation "true"
+
+  - set_application_folder "$APPLICATION_FOLDER"
+  - set_sketchbook_folder "$SKETCHBOOK_FOLDER"
+
+
+notifications:
+  email:
+    on_success: always
+    on_failure: always
+  webhooks:
+    urls:
+      - https://www.travisbuddy.com/
+    on_success: never
+    on_failure: always

--- a/examples/MCP2515-Loopback/MCP2515-Loopback.ino
+++ b/examples/MCP2515-Loopback/MCP2515-Loopback.ino
@@ -40,7 +40,7 @@ void setup()
   MCP2515.begin();
   MCP2515.setBitRate(CanBitRate::BR_250kBPS);
   MCP2515.setLoopbackMode();
-  
+
   std::for_each(TEST_ID_VECTOR.cbegin(),
                 TEST_ID_VECTOR.cend(),
                 [](uint32_t const id)
@@ -54,7 +54,7 @@ void setup()
 
 void loop()
 {
-  
+
 }
 
 /**************************************************************************************

--- a/src/MCP2515/MCP2515_Event.h
+++ b/src/MCP2515/MCP2515_Event.h
@@ -20,7 +20,7 @@ public:
 
          void begin();
   static void onExternalEvent();
-  
+
 
 private:
 


### PR DESCRIPTION
- Compile all sketches under the examples folder for MKR Vidor 4000 using the latest version of the Arduino IDE.
  - A tab separated table summarizing the compilation results is printed to the Travis CI log.
- Check for common problems with Arduino libraries and sketches that aren't caught by a compilation test.
- Spell check all files.
  - In the event of false positives, the word can be added to the ignore list at `etc/codespell-ignore-words-list.txt`. Note that it should be in lower case.
- Check for consistent file formatting.
  - Files may not start with a blank line.
  - Use of true tabs is only allowed in keywords.txt.
  - Files may not have trailing whitespace.
  - Files must use Unix-style line endings.
  - Extra blanks lines are not allowed at the end of files.
  - Files must end in a newline.
- Use TravisBuddy to comment on pull requests that result in a failed Travis CI build.