### PR TITLE
Restrict list of supported architectures to samd

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,5 +6,5 @@ sentence=Arduino library for controlling the MCP2515 in order to receive/transmi
 paragraph=
 category=Communication
 url=https://github.com/107-systems/107-Arduino-MCP2515
-architectures=*
+architectures=samd
 includes=ArduinoMCP2515.h


### PR DESCRIPTION
Since `107-Arduino-MCP2515` uses advanced C++ features such as `<functional>` it can not be compiled for AVR boards. Therefore it is a good idea to specify the supported architectures which is currently `samd` only.

This PR fixes #10 since it gives users a warning when compiling for a different architecture then samd.