### PR TITLE
Support libcanard defined types for receiving/transmitting

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ void    onReceiveBufferFull   (uint32_t const id, uint8_t const * data, uint8_t 
 void    onTransmitBufferEmpty (ArduinoMCP2515 * this_ptr)                                  { /* You can use this callback to refill the transmit buffer via this_ptr->transmit(...) */ }
 void    onMCP2515ExternalEvent()                                                           { mcp2515.onExternalEventHandler(); }
 /* ... */
-ArduinoMCP2515 mcp2515(spi_select, spi_deselect, spi_transfer, onReceiveBufferFull, onTransmitBufferEmpty);
+ArduinoMCP2515 mcp2515(spi_select, spi_deselect, spi_transfer, micros, onReceiveBufferFull, onTransmitBufferEmpty);
 /* ... */
 void setup() {
   Serial.begin(9600);

--- a/examples/MCP2515-CAN-Sniffer/MCP2515-CAN-Sniffer.ino
+++ b/examples/MCP2515-CAN-Sniffer/MCP2515-CAN-Sniffer.ino
@@ -39,6 +39,7 @@ void    onReceiveBufferFull  (uint32_t const, uint8_t const *, uint8_t const);
 ArduinoMCP2515 mcp2515(spi_select,
                        spi_deselect,
                        spi_transfer,
+                       micros,
                        onReceiveBufferFull,
                        nullptr);
 

--- a/examples/MCP2515-Loopback/MCP2515-Loopback.ino
+++ b/examples/MCP2515-Loopback/MCP2515-Loopback.ino
@@ -73,6 +73,7 @@ static std::array<sCanTestFrame, 7> const CAN_TEST_FRAME_ARRAY =
 ArduinoMCP2515 mcp2515(spi_select,
                        spi_deselect,
                        spi_transfer,
+                       micros,
                        onReceiveBufferFull,
                        nullptr);
 

--- a/src/ArduinoMCP2515.cpp
+++ b/src/ArduinoMCP2515.cpp
@@ -52,11 +52,13 @@ inline bool isBitClr(uint8_t const reg_val, uint8_t const bit_pos)
 ArduinoMCP2515::ArduinoMCP2515(SpiSelectFunc select,
                                SpiDeselectFunc deselect,
                                SpiTransferFunc transfer,
+                               MicroSecondFunc micros,
                                OnReceiveBufferFullFunc on_rx_buf_full,
                                OnTransmitBufferEmptyFunc on_tx_buf_empty)
 : _io{select, deselect, transfer}
 , _cfg{_io}
 , _ctrl{_io}
+, _micros{micros}
 , _on_rx_buf_full{on_rx_buf_full}
 , _on_tx_buf_empty{on_tx_buf_empty}
 {
@@ -174,7 +176,7 @@ void ArduinoMCP2515::onReceiveBuffer_n_Full(uint32_t const id, uint8_t const * d
 #if LIBCANARD
     CanardFrame const frame
     {
-      0,                                     /* timestamp_usec  */
+      _micros(),                             /* timestamp_usec  */
       id,                                    /* extended_can_id */
       len,                                   /* payload_size    */
       reinterpret_cast<const void *>(data)}; /* payload         */

--- a/src/ArduinoMCP2515.cpp
+++ b/src/ArduinoMCP2515.cpp
@@ -13,10 +13,6 @@
 
 #include <algorithm>
 
-#if LIBCANARD
-#  include <string.h>
-#endif
-
 /**************************************************************************************
  * NAMESPACE
  **************************************************************************************/
@@ -176,8 +172,12 @@ void ArduinoMCP2515::onReceiveBuffer_n_Full(uint32_t const id, uint8_t const * d
   if (_on_rx_buf_full)
   {
 #if LIBCANARD
-    CanardFrame frame{0, id, len, 0};
-    memcpy((void*)frame.payload, data, len);
+    CanardFrame const frame
+    {
+      0,                                     /* timestamp_usec  */
+      id,                                    /* extended_can_id */
+      len,                                   /* payload_size    */
+      reinterpret_cast<const void *>(data)}; /* payload         */
     _on_rx_buf_full(frame);
 #else
     _on_rx_buf_full(id, data, len);

--- a/src/ArduinoMCP2515.cpp
+++ b/src/ArduinoMCP2515.cpp
@@ -106,6 +106,15 @@ bool ArduinoMCP2515::transmit(uint32_t const id, uint8_t const * data, uint8_t c
   }
 }
 
+#if LIBCANARD
+bool ArduinoMCP2515::transmit(CanardFrame const & frame)
+{
+  return transmit(frame.extended_can_id,
+                  reinterpret_cast<uint8_t const *>(frame.payload),
+                  static_cast<uint8_t const>(frame.payload_size));
+}
+#endif
+
 void ArduinoMCP2515::onExternalEventHandler()
 {
   uint8_t const status = _ctrl.status();
@@ -124,7 +133,15 @@ void ArduinoMCP2515::onReceiveBuffer_0_Full()
 
   _ctrl.receive(RxB::RxB0, id, data, len);
   if (_on_rx_buf_full)
+  {
+#if LIBCANARD
+    CanardFrame const frame{0, id, len, 0};
+    _on_rx_buf_full(frame);
+#else
     _on_rx_buf_full(id, data, len);
+#endif
+  }
+
   _ctrl.clearIntFlag(CANINTF::RX0IF);
 }
 
@@ -135,7 +152,15 @@ void ArduinoMCP2515::onReceiveBuffer_1_Full()
 
   _ctrl.receive(RxB::RxB1, id, data, len);
   if (_on_rx_buf_full)
+  {
+#if LIBCANARD
+    CanardFrame const frame{0, id, len, 0};
+    _on_rx_buf_full(frame);
+#else
     _on_rx_buf_full(id, data, len);
+#endif
+  }
+
   _ctrl.clearIntFlag(CANINTF::RX1IF);
 }
 

--- a/src/ArduinoMCP2515.cpp
+++ b/src/ArduinoMCP2515.cpp
@@ -177,7 +177,7 @@ void ArduinoMCP2515::onReceiveBuffer_n_Full(uint32_t const id, uint8_t const * d
   {
 #if LIBCANARD
     CanardFrame frame{0, id, len, 0};
-    memcpy(frame.payload, data, len);
+    memcpy((void*)frame.payload, data, len);
     _on_rx_buf_full(frame);
 #else
     _on_rx_buf_full(id, data, len);

--- a/src/ArduinoMCP2515.h
+++ b/src/ArduinoMCP2515.h
@@ -26,12 +26,12 @@
 #include <functional>
 
 #if defined __has_include
-#  if __has_include (<canard.h>)
-#    include <canard.h>
+#  if __has_include (<libcanard/canard.h>)
+#    include <libcanard/canard.h>
 #    define LIBCANARD 1
 #  endif
 #else
-#    define LIBCANARD 0
+#  define LIBCANARD 0
 #endif
 
 /**************************************************************************************

--- a/src/ArduinoMCP2515.h
+++ b/src/ArduinoMCP2515.h
@@ -101,7 +101,7 @@ private:
   void onTransmitBuffer_0_Empty();
   void onTransmitBuffer_1_Empty();
   void onTransmitBuffer_2_Empty();
-
+  void onReceiveBuffer_n_Full(uint32_t const id, uint8_t const * data, uint8_t const len) const;
 };
 
 #endif /* ARDUINO_MCP2515_H_ */

--- a/src/ArduinoMCP2515.h
+++ b/src/ArduinoMCP2515.h
@@ -25,6 +25,15 @@
 #include <string>
 #include <functional>
 
+#if defined __has_include
+#  if __has_include (<canard.h>)
+#    include <canard.h>
+#    define LIBCANARD 1
+#  endif
+#else
+#    define LIBCANARD 0
+#endif
+
 /**************************************************************************************
  * TYPEDEF
  **************************************************************************************/
@@ -38,7 +47,11 @@ enum class CanBitRate : size_t
 };
 
 class ArduinoMCP2515;
+#if LIBCANARD
+typedef std::function<void(CanardFrame const & frame)> OnReceiveBufferFullFunc;
+#else
 typedef std::function<void(uint32_t const, uint8_t const *, uint8_t const)> OnReceiveBufferFullFunc;
+#endif
 typedef std::function<void(ArduinoMCP2515 *)> OnTransmitBufferEmptyFunc;
 
 /**************************************************************************************
@@ -68,6 +81,9 @@ public:
   inline bool setConfigMode    () { return _cfg.setMode(MCP2515::Mode::Config);     }
 
   bool transmit(uint32_t const id, uint8_t const * data, uint8_t const len);
+#if LIBCANARD
+  bool transmit(CanardFrame const & frame);
+#endif
 
   void onExternalEventHandler();
 

--- a/src/ArduinoMCP2515.h
+++ b/src/ArduinoMCP2515.h
@@ -29,6 +29,9 @@
 #  if __has_include (<libcanard/canard.h>)
 #    include <libcanard/canard.h>
 #    define LIBCANARD 1
+#  elif __has_include (<canard.h>)
+#    include <canard.h>
+#    define LIBCANARD 1
 #  endif
 #else
 #  define LIBCANARD 0

--- a/src/ArduinoMCP2515.h
+++ b/src/ArduinoMCP2515.h
@@ -46,12 +46,13 @@ enum class CanBitRate : size_t
   BR_1000kBPS = 3
 };
 
-class ArduinoMCP2515;
+typedef std::function<unsigned long()> MicroSecondFunc;
 #if LIBCANARD
 typedef std::function<void(CanardFrame const & frame)> OnReceiveBufferFullFunc;
 #else
 typedef std::function<void(uint32_t const, uint8_t const *, uint8_t const)> OnReceiveBufferFullFunc;
 #endif
+class ArduinoMCP2515;
 typedef std::function<void(ArduinoMCP2515 *)> OnTransmitBufferEmptyFunc;
 
 /**************************************************************************************
@@ -66,6 +67,7 @@ public:
   ArduinoMCP2515(MCP2515::SpiSelectFunc select,
                  MCP2515::SpiDeselectFunc deselect,
                  MCP2515::SpiTransferFunc transfer,
+                 MicroSecondFunc micros,
                  OnReceiveBufferFullFunc on_rx_buf_full,
                  OnTransmitBufferEmptyFunc on_tx_buf_empty);
 
@@ -93,6 +95,7 @@ private:
   MCP2515::MCP2515_Io _io;
   MCP2515::MCP2515_Config _cfg;
   MCP2515::MCP2515_Control _ctrl;
+  MicroSecondFunc _micros;
   OnReceiveBufferFullFunc _on_rx_buf_full;
   OnTransmitBufferEmptyFunc _on_tx_buf_empty;
 


### PR DESCRIPTION
This PR adds the feature of automatically supporting the libcanard defined [CanardFrame](https://github.com/UAVCAN/libcanard/blob/master/libcanard/canard.h#L198) type for receiving/transmitting of CAN frames when [libcanard](https://github.com/UAVCAN/libcanard) is present in the build project. Therefore this PR prepares the repository being included in [UAVCAN/platform_specific_components](https://github.com/UAVCAN/platform_specific_components) as dicusssed in https://github.com/UAVCAN/platform_specific_components/issues/15 .

What do you think @pavel-kirienko ?
