### PR TITLE
Update CI system

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -19,6 +19,25 @@ jobs:
     env:
       SKETCHES_REPORTS_PATH: sketches-reports
 
+    strategy:
+      fail-fast: false
+
+      matrix:
+        fqbn:
+          - arduino:samd:mkr1000
+          - arduino:samd:mkrzero
+          - arduino:samd:mkrwifi1010
+          - arduino:samd:mkrfox1200
+          - arduino:samd:mkrwan1300
+          - arduino:samd:mkrwan1310
+          - arduino:samd:mkrgsm1400
+          - arduino:samd:mkrnb1500
+          - arduino:samd:mkrvidor4000
+          # These should be changed from to the "arduino-beta" vendor to "arduino" once there is a production release of Arduino mbed-Enabled Boards
+          - arduino-beta:mbed:envie_m7
+          - arduino-beta:mbed:envie_m4
+          - arduino-beta:mbed:nano33ble
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -26,7 +45,7 @@ jobs:
       - name: Compile examples
         uses: arduino/compile-sketches@main
         with:
-          fqbn: arduino:samd:mkrvidor4000
+          fqbn: ${{ matrix.fqbn }}
           enable-deltas-report: true
           sketches-report-path: ${{ env.SKETCHES_REPORTS_PATH }}
 

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -27,8 +27,7 @@ jobs:
         uses: arduino/compile-sketches@main
         with:
           fqbn: arduino:samd:mkrvidor4000
-          size-report-sketch: MCP2515-Loopback
-          enable-size-deltas-report: true
+          enable-deltas-report: true
           sketches-report-path: ${{ env.SKETCHES_REPORTS_PATH }}
 
       - name: Save memory usage change report as artifact

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -16,20 +16,24 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    env:
+      SKETCHES_REPORTS_PATH: sketches-reports
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2
 
       - name: Compile examples
-        uses: arduino/actions/libraries/compile-examples@master
+        uses: arduino/compile-sketches@main
         with:
           fqbn: arduino:samd:mkrvidor4000
           size-report-sketch: MCP2515-Loopback
           enable-size-deltas-report: true
+          sketches-report-path: ${{ env.SKETCHES_REPORTS_PATH }}
 
       - name: Save memory usage change report as artifact
         if: github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
-          name: size-deltas-reports
-          path: size-deltas-reports
+          name: ${{ env.SKETCHES_REPORTS_PATH }}
+          path: ${{ env.SKETCHES_REPORTS_PATH }}

--- a/.github/workflows/report-size-deltas.yml
+++ b/.github/workflows/report-size-deltas.yml
@@ -11,4 +11,7 @@ jobs:
     steps:
       # See: https://github.com/arduino/actions/blob/master/libraries/report-size-deltas/README.md
       - name: Comment size deltas reports to PRs
-        uses: arduino/actions/libraries/report-size-deltas@master
+        uses: arduino/report-size-deltas@main
+        with:
+          # The name of the workflow artifact created by the "Compile Examples" workflow
+          sketches-reports-source: sketches-reports


### PR DESCRIPTION
- Update action names in CI workflows
- Use modern API of the arduino/compile-sketches CI action
- Run Compile Examples CI workflow for all MKR and Mbed-enabled boards

Fixes https://github.com/107-systems/107-Arduino-MCP2515/issues/20

Note: Due to a breaking chance made to the `arduino/report-size-deltas` action during its transition from `arduino/actions/libraries/report-size-deltas` and the way GitHub Actions runs scheduled workflows only from the repository default branch, the deltas report comment will not be made for this PR. However, after this PR is merged, the report should resume for all future PRs.