### PR TITLE
Update Portenta platform in Compile Examples CI workflow

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -33,10 +33,9 @@ jobs:
           - arduino:samd:mkrgsm1400
           - arduino:samd:mkrnb1500
           - arduino:samd:mkrvidor4000
-          # These should be changed from to the "arduino-beta" vendor to "arduino" once there is a production release of Arduino mbed-Enabled Boards
-          - arduino-beta:mbed:envie_m7
-          - arduino-beta:mbed:envie_m4
-          - arduino-beta:mbed:nano33ble
+          - arduino:mbed:envie_m7
+          - arduino:mbed:envie_m4
+          - arduino:mbed:nano33ble
 
     steps:
       - name: Checkout


### PR DESCRIPTION
The beta phase `arduino-beta:mbed` boards platform of the Portenta H7 has been deprecated, which will cause platform installation during the compilation check CI to fail if the old name is used.

Reference: https://github.com/arduino/ArduinoCore-mbed/issues/72