### PR TITLE
Provide a constant CAN_ADR_BITMASK to replace magic value 0x1FFFFFFF.

### DIFF
--- a/src/ArduinoMCP2515.cpp
+++ b/src/ArduinoMCP2515.cpp
@@ -188,7 +188,7 @@ void ArduinoMCP2515::onReceiveBuffer_n_Full(unsigned long const timestamp_us, ui
     CanardFrame const frame
     {
       timestamp_us,                        /* timestamp_usec  */
-      id&0x1FFFFFFF,                       /* extended_can_id limited to 29 bit */
+      id & CAN_ADR_BITMASK,                /* extended_can_id limited to 29 bit */
       len,                                 /* payload_size    */
       reinterpret_cast<const void *>(data) /* payload         */
     };

--- a/src/MCP2515/MCP2515_Const.h
+++ b/src/MCP2515/MCP2515_Const.h
@@ -240,6 +240,7 @@ static uint8_t constexpr RXB1CTRL_RXM_MASK  = bm(RXB1CTRL::RXM1)  | bm(RXB1CTRL:
 static uint32_t constexpr CAN_EFF_BITMASK   = 0x80000000;
 static uint32_t constexpr CAN_RTR_BITMASK   = 0x40000000;
 static uint32_t constexpr CAN_ERR_BITMASK   = 0x20000000;
+static uint32_t constexpr CAN_ADR_BITMASK   = ~(CAN_EFF_BITMASK | CAN_RTR_BITMASK | CAN_ERR_BITMASK);
 
 /**************************************************************************************
  * NAMESPACE


### PR DESCRIPTION
The magic value `0x1FFFFFFF` is currently used for filtering away the top 3 bits of CAN ID before feeding it into a `libcanard` CanardFrame. Using a named constand explains more clearly why the code construct is there in the first place.