### PR TITLE
Replace top-level include file for 107-Arduino-MCP2515.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This library works for
 ## Example
 ```C++
 #include <SPI.h>
-#include <ArduinoMCP2515.h>
+#include <107-Arduino-MCP2515.h>
 /* ... */
 static int const MKRCAN_MCP2515_CS_PIN  = 3;
 static int const MKRCAN_MCP2515_INT_PIN = 7;

--- a/examples/MCP2515-CAN-Sniffer/MCP2515-CAN-Sniffer.ino
+++ b/examples/MCP2515-CAN-Sniffer/MCP2515-CAN-Sniffer.ino
@@ -9,7 +9,7 @@
 
 #include <SPI.h>
 
-#include <ArduinoMCP2515.h>
+#include <107-Arduino-MCP2515.h>
 
 #undef max
 #undef min

--- a/examples/MCP2515-Loopback/MCP2515-Loopback.ino
+++ b/examples/MCP2515-Loopback/MCP2515-Loopback.ino
@@ -9,7 +9,7 @@
 
 #include <SPI.h>
 
-#include <ArduinoMCP2515.h>
+#include <107-Arduino-MCP2515.h>
 
 #undef max
 #undef min

--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=
 category=Communication
 url=https://github.com/107-systems/107-Arduino-MCP2515
 architectures=samd,esp32,mbed,mbed_nano,mbed_portenta,mbed_edge,rp2040
-includes=ArduinoMCP2515.h
+includes=107-Arduino-MCP2515.h

--- a/src/107-Arduino-MCP2515.h
+++ b/src/107-Arduino-MCP2515.h
@@ -1,0 +1,17 @@
+/**
+ * This software is distributed under the terms of the MIT License.
+ * Copyright (c) 2020 LXRobotics.
+ * Author: Alexander Entinger <alexander.entinger@lxrobotics.com>
+ * Contributors: https://github.com/107-systems/107-Arduino-MCP2515/graphs/contributors.
+ */
+
+#ifndef _107_MCP2515_H_
+#define _107_MCP2515_H_
+
+/**************************************************************************************
+ * INCLUDE
+ **************************************************************************************/
+
+#include "ArduinoMCP2515.h"
+
+#endif /* _107_MCP2515_H_ */

--- a/src/ArduinoMCP2515.cpp
+++ b/src/ArduinoMCP2515.cpp
@@ -9,7 +9,7 @@
  * INCLUDE
  **************************************************************************************/
 
-#include <ArduinoMCP2515.h>
+#include <107-Arduino-MCP2515.h>
 
 #include <algorithm>
 


### PR DESCRIPTION
This is done to share the same name as the library (and because a header file may in fact start with a number).