### PR TITLE
Feature Request #60: Add inline documentation for CanBitRate

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ void setup()
   attachInterrupt(digitalPinToInterrupt(MKRCAN_MCP2515_INT_PIN), [](){ mcp2515.onExternalEventHandler(); }, FALLING);
 
   mcp2515.begin();
-  mcp2515.setBitRate(CanBitRate::BR_250kBPS_16MHZ);
+  mcp2515.setBitRate(CanBitRate::BR_250kBPS_16MHZ); // CAN bitrate and clock speed of MCP2515
   mcp2515.setNormalMode();
 }
 

--- a/examples/MCP2515-CAN-Sniffer/MCP2515-CAN-Sniffer.ino
+++ b/examples/MCP2515-CAN-Sniffer/MCP2515-CAN-Sniffer.ino
@@ -58,7 +58,7 @@ void setup()
   attachInterrupt(digitalPinToInterrupt(MKRCAN_MCP2515_INT_PIN), [](){ mcp2515.onExternalEventHandler(); }, FALLING);
 
   mcp2515.begin();
-  mcp2515.setBitRate(CanBitRate::BR_250kBPS_16MHZ);
+  mcp2515.setBitRate(CanBitRate::BR_250kBPS_16MHZ); // CAN bit rate and MCP2515 clock speed
   mcp2515.setListenOnlyMode();
 }
 

--- a/examples/MCP2515-Loopback/MCP2515-Loopback.ino
+++ b/examples/MCP2515-Loopback/MCP2515-Loopback.ino
@@ -92,7 +92,7 @@ void setup()
   attachInterrupt(digitalPinToInterrupt(MKRCAN_MCP2515_INT_PIN), [](){ mcp2515.onExternalEventHandler(); }, FALLING);
 
   mcp2515.begin();
-  mcp2515.setBitRate(CanBitRate::BR_250kBPS_16MHZ);
+  mcp2515.setBitRate(CanBitRate::BR_250kBPS_16MHZ); // CAN bit rate and MCP2515 clock speed
   mcp2515.setLoopbackMode();
 
   std::for_each(CAN_TEST_FRAME_ARRAY.cbegin(),


### PR DESCRIPTION
added some small inline comments to provoke developers to make sure they adjust these lines and also explain that the suffix frequency is related to the oscillator/clock rate of the MCP2515 chip they are using.