### PR TITLE
Fix: Only use a single transmit buffer when transmitting OpenCyphal/CAN frames.

### DIFF
--- a/src/ArduinoMCP2515.cpp
+++ b/src/ArduinoMCP2515.cpp
@@ -133,6 +133,13 @@ bool ArduinoMCP2515::transmitCANFrame(uint32_t const id, uint8_t const * data, u
     return true;
   }
 
+#if LIBCANARD
+  /* Only use a single transmit buffer in order to prevent unintentional
+   * priority inversion while transmitting OpenCyphal/CAN frames.
+   */
+  return false;
+#endif
+
   if (isBitClr(_io.readRegister(Register::TXB1CTRL), bp(TXBnCTRL::TXREQ)))
   {
     _ctrl.transmit(TxB::TxB1, id, data, len);


### PR DESCRIPTION
See https://forum.opencyphal.org/t/uavcan-can-tx-buffer-management-in-can-fd-controllers/1215 .