### PR TITLE
Fix: Only enable transmit buffer empty interrupt if such a callback if provided by the user.

### DIFF
--- a/src/ArduinoMCP2515.cpp
+++ b/src/ArduinoMCP2515.cpp
@@ -80,9 +80,12 @@ void ArduinoMCP2515::begin()
   _cfg.disableFilter_RxB1();
   _cfg.enableRollover_RxB0();
 
-  _cfg.enableIntFlag(CANINTE::TX0IE);
-  _cfg.enableIntFlag(CANINTE::TX1IE);
-  _cfg.enableIntFlag(CANINTE::TX2IE);
+  if (_on_tx_buf_empty)
+  {
+    _cfg.enableIntFlag(CANINTE::TX0IE);
+    _cfg.enableIntFlag(CANINTE::TX1IE);
+    _cfg.enableIntFlag(CANINTE::TX2IE);
+  }
 
   if (_on_rx_buf_full)
   {


### PR DESCRIPTION
This saves unnecessary interrupts reducing the amount of necessary SPI transactions.