### PR TITLE
Use arduino/compile-sketches@v1 instead of @main.

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -84,7 +84,7 @@ jobs:
         run: pip3 install pyserial
 
       - name: Compile examples
-        uses: arduino/compile-sketches@main
+        uses: arduino/compile-sketches@v1
         with:
           fqbn: ${{ matrix.board.fqbn }}
           platforms: ${{ matrix.board.platforms }}


### PR DESCRIPTION
The latter may sometimes contain regressions.

FYI @per1234 - ESP32 regression still there.