### PR TITLE
Add example demonstrating a HardwareCAN wrapper allowing to have standardised CAN on any Arduino board.

### DIFF
--- a/examples/MCP2515-Filter/MCP2515-Filter.ino
+++ b/examples/MCP2515-Filter/MCP2515-Filter.ino
@@ -60,7 +60,7 @@ void setup()
   attachInterrupt(digitalPinToInterrupt(MKRCAN_MCP2515_INT_PIN), [](){ mcp2515.onExternalEventHandler(); }, LOW);
 
   mcp2515.begin();
-  mcp2515.setBitRate(CanBitRate::BR_250kBPS_16MHZ); // CAN bit rate and MCP2515 clock speed
+  mcp2515.setBitRate(MCP2515::CanBitRate::BR_250kBPS_16MHZ); // CAN bit rate and MCP2515 clock speed
   mcp2515.setListenOnlyMode();
 
   /* Enable filtering of CAN messages. The MCP2515 has two message receive buffers.

--- a/examples/MCP2515-Loopback/MCP2515-Loopback.ino
+++ b/examples/MCP2515-Loopback/MCP2515-Loopback.ino
@@ -94,7 +94,7 @@ void setup()
   attachInterrupt(digitalPinToInterrupt(MKRCAN_MCP2515_INT_PIN), [](){ mcp2515.onExternalEventHandler(); }, LOW);
 
   mcp2515.begin();
-  mcp2515.setBitRate(CanBitRate::BR_250kBPS_16MHZ); // CAN bit rate and MCP2515 clock speed
+  mcp2515.setBitRate(MCP2515::CanBitRate::BR_250kBPS_16MHZ); // CAN bit rate and MCP2515 clock speed
   mcp2515.setLoopbackMode();
 
   std::for_each(CAN_TEST_FRAME_ARRAY.cbegin(),

--- a/src/ArduinoMCP2515.cpp
+++ b/src/ArduinoMCP2515.cpp
@@ -123,7 +123,7 @@ void ArduinoMCP2515::begin()
   }
 }
 
-void ArduinoMCP2515::setBitRate(CanBitRate const bit_rate)
+void ArduinoMCP2515::setBitRate(MCP2515::CanBitRate const bit_rate)
 {
   _cfg.setBitRateConfig(BIT_RATE_CONFIG_ARRAY[static_cast<size_t>(bit_rate)]);
 }

--- a/src/ArduinoMCP2515.h
+++ b/src/ArduinoMCP2515.h
@@ -41,6 +41,9 @@
  * TYPEDEF
  **************************************************************************************/
 
+namespace MCP2515
+{
+
 enum class CanBitRate : size_t
 {
   BR_10kBPS_16MHZ = 0,
@@ -82,6 +85,8 @@ enum class CanBitRate : size_t
   BR_1000kBPS_12MHZ
 };
 
+} /* MCP2515 */
+
 typedef std::function<unsigned long()> MicroSecondFunc;
 #if LIBCANARD
 typedef std::function<void(CanardFrame const & frame)> OnReceiveBufferFullFunc;
@@ -110,7 +115,7 @@ public:
 
   void begin();
 
-  void setBitRate(CanBitRate const bit_rate);
+  void setBitRate(MCP2515::CanBitRate const bit_rate);
 
   inline bool setNormalMode    () { return _cfg.setMode(MCP2515::Mode::Normal);     }
   inline bool setSleepMode     () { return _cfg.setMode(MCP2515::Mode::Sleep);      }


### PR DESCRIPTION
Requires https://github.com/arduino/ArduinoCore-API/pull/185 .