### PR TITLE
Fix: When writing filter IDs the writing should start from SIDH.

### DIFF
--- a/examples/MCP2515-Filter/MCP2515-Filter.ino
+++ b/examples/MCP2515-Filter/MCP2515-Filter.ino
@@ -61,7 +61,6 @@ void setup()
 
   mcp2515.begin();
   mcp2515.setBitRate(CanBitRate::BR_250kBPS_16MHZ); // CAN bit rate and MCP2515 clock speed
-  mcp2515.setListenOnlyMode();
 
   /* Enable filtering of CAN messages. The MCP2515 has two message receive buffers.
    * For each message receive buffer a filter mask can be defined. In addition, for
@@ -95,6 +94,9 @@ void setup()
     0x00000008
   };
   mcp2515.enableFilter(MCP2515::RxB::RxB1, RXMB1_MASK, RXMB1_FILTER, RXMB1_FILTER_SIZE);
+
+  /* Leave configuration mode and start listening. */
+  mcp2515.setListenOnlyMode();
 }
 
 void loop()

--- a/src/MCP2515/MCP2515_Config.h
+++ b/src/MCP2515/MCP2515_Config.h
@@ -98,12 +98,12 @@ public:
          bool setMode            (Mode const mode);
          void setBitRateConfig   (CanBitRateConfig const bit_rate_config);
 
-  inline void setFilterId_RxF0  (uint32_t const id)   { setFilterId(Register::RXF0SIDL, id); }
-  inline void setFilterId_RxF1  (uint32_t const id)   { setFilterId(Register::RXF1SIDL, id); }
-  inline void setFilterId_RxF2  (uint32_t const id)   { setFilterId(Register::RXF2SIDL, id); }
-  inline void setFilterId_RxF3  (uint32_t const id)   { setFilterId(Register::RXF3SIDL, id); }
-  inline void setFilterId_RxF4  (uint32_t const id)   { setFilterId(Register::RXF4SIDL, id); }
-  inline void setFilterId_RxF5  (uint32_t const id)   { setFilterId(Register::RXF5SIDL, id); }
+  inline void setFilterId_RxF0  (uint32_t const id)   { setFilterId(Register::RXF0SIDH, id); }
+  inline void setFilterId_RxF1  (uint32_t const id)   { setFilterId(Register::RXF1SIDH, id); }
+  inline void setFilterId_RxF2  (uint32_t const id)   { setFilterId(Register::RXF2SIDH, id); }
+  inline void setFilterId_RxF3  (uint32_t const id)   { setFilterId(Register::RXF3SIDH, id); }
+  inline void setFilterId_RxF4  (uint32_t const id)   { setFilterId(Register::RXF4SIDH, id); }
+  inline void setFilterId_RxF5  (uint32_t const id)   { setFilterId(Register::RXF5SIDH, id); }
   inline void setFilterMask_RxB0(uint32_t const mask) { setFilterMask(Register::RXM0SIDH, mask); }
   inline void setFilterMask_RxB1(uint32_t const mask) { setFilterMask(Register::RXM1SIDH, mask); }
 


### PR DESCRIPTION
FYI @generationmake make sure to get the latest version after I merge this fix.